### PR TITLE
Add support for the NO_COLOR environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         run: deno task build
 
       - name: Test
-        run: deno test
+        run: deno test --allow-env

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,5 @@
 import { assert } from "./assert.ts";
+import { env } from "./environment.ts";
 
 /**
  * Options that can be set for the expect function.
@@ -25,11 +26,13 @@ export interface ExpectConfig extends RenderConfig, RetryConfig {
  * @returns the default configuration
  */
 export function makeDefaultConfig(): ExpectConfig {
+  const noColor = env.NO_COLOR !== undefined;
+
   return {
     ...DEFAULT_RETRY_OPTIONS,
     soft: false,
     display: "pretty",
-    colorize: true,
+    colorize: !noColor,
     assertFn: assert,
   };
 }

--- a/environment.ts
+++ b/environment.ts
@@ -1,0 +1,22 @@
+// In the k6 runtime, the __ENV object is available and contains the environment variables.
+export declare const __ENV: Record<string, string | undefined>;
+
+/**
+ * Environment interface that matches the shape of k6's __ENV object.
+ */
+export interface Environment {
+    [key: string]: string | undefined;
+}
+
+function getEnvironment(): Environment {
+  // When running in Deno
+  if (typeof Deno !== "undefined") {
+    return Deno.env.toObject();
+  }
+
+  // When running in k6
+  return __ENV;
+}
+
+// Export a singleton instance of the environment object
+export const env: Environment = getEnvironment();

--- a/environment.ts
+++ b/environment.ts
@@ -5,7 +5,7 @@ export declare const __ENV: Record<string, string | undefined>;
  * Environment interface that matches the shape of k6's __ENV object.
  */
 export interface Environment {
-    [key: string]: string | undefined;
+  [key: string]: string | undefined;
 }
 
 function getEnvironment(): Environment {

--- a/expect.test.ts
+++ b/expect.test.ts
@@ -4,30 +4,36 @@ import { expect } from "./expect.ts";
 import { env } from "./environment.ts";
 
 Deno.test("expect.configure", async (t) => {
-    await t.step("NO_COLOR environment variable should have priority over colorize option", () => {
-        withEnv("NO_COLOR", "true", () => {
-            const ex = expect.configure({
-                colorize: true,
-            });
-
-            assertEquals(ex.config.colorize, false);
-        });
-    })
-
-    await t.step("When NO_COLOR is not set, colorize option should have priority over NO_COLOR environment variable", () => {
-        // Assuming NO_COLOR is not set in the environment, the colorize option should be the source of truth
+  await t.step(
+    "NO_COLOR environment variable should have priority over colorize option",
+    () => {
+      withEnv("NO_COLOR", "true", () => {
         const ex = expect.configure({
-            colorize: true,
+          colorize: true,
         });
 
-        assertEquals(ex.config.colorize, true);
-    })
-})
+        assertEquals(ex.config.colorize, false);
+      });
+    },
+  );
+
+  await t.step(
+    "When NO_COLOR is not set, colorize option should have priority over NO_COLOR environment variable",
+    () => {
+      // Assuming NO_COLOR is not set in the environment, the colorize option should be the source of truth
+      const ex = expect.configure({
+        colorize: true,
+      });
+
+      assertEquals(ex.config.colorize, true);
+    },
+  );
+});
 
 // Helper function to set an environment variable for the duration of a test
 function withEnv(key: string, value: string, fn: () => void) {
-    const originalValue = env[key];
-    env[key] = value;
-    fn();
-    env[key] = originalValue;
+  const originalValue = env[key];
+  env[key] = value;
+  fn();
+  env[key] = originalValue;
 }

--- a/expect.test.ts
+++ b/expect.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "jsr:@std/assert";
+
+import { expect } from "./expect.ts";
+import { env } from "./environment.ts";
+
+Deno.test("expect.configure", async (t) => {
+    await t.step("NO_COLOR environment variable should have priority over colorize option", () => {
+        withEnv("NO_COLOR", "true", () => {
+            const ex = expect.configure({
+                colorize: true,
+            });
+
+            assertEquals(ex.config.colorize, false);
+        });
+    })
+
+    await t.step("When NO_COLOR is not set, colorize option should have priority over NO_COLOR environment variable", () => {
+        // Assuming NO_COLOR is not set in the environment, the colorize option should be the source of truth
+        const ex = expect.configure({
+            colorize: true,
+        });
+
+        assertEquals(ex.config.colorize, true);
+    })
+})
+
+// Helper function to set an environment variable for the duration of a test
+function withEnv(key: string, value: string, fn: () => void) {
+    const originalValue = env[key];
+    env[key] = value;
+    fn();
+    env[key] = originalValue;
+}

--- a/expect.ts
+++ b/expect.ts
@@ -106,10 +106,10 @@ function makeExpect(baseConfig?: Partial<ExpectConfig>): ExpectFunction {
       },
       configure(newConfig: Partial<ExpectConfig>): ExpectFunction {
         const colorDeactivated = env.NO_COLOR !== undefined;
-        return makeExpect({ 
-          ...mergedConfig, 
+        return makeExpect({
+          ...mergedConfig,
           ...newConfig,
-          ...(colorDeactivated ? { colorize: false } : {})
+          ...(colorDeactivated ? { colorize: false } : {}),
         });
       },
       get config(): ExpectConfig {

--- a/expect.ts
+++ b/expect.ts
@@ -1,5 +1,6 @@
 import type { Locator } from "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/refs/heads/master/types/k6/browser/index.d.ts";
 import { type ExpectConfig, makeDefaultConfig } from "./config.ts";
+import { env } from "./environment.ts";
 import {
   createExpectation as createNonRetryingExpectation,
   type NonRetryingExpectation,
@@ -45,6 +46,11 @@ export interface ExpectFunction {
    * Creates a new expect instance with the given configuration.
    */
   configure(newConfig: Partial<ExpectConfig>): ExpectFunction;
+
+  /**
+   * The configuration used by the expect function.
+   */
+  readonly config: ExpectConfig;
 }
 
 /**
@@ -99,7 +105,15 @@ function makeExpect(baseConfig?: Partial<ExpectConfig>): ExpectFunction {
         }
       },
       configure(newConfig: Partial<ExpectConfig>): ExpectFunction {
-        return makeExpect({ ...mergedConfig, ...newConfig });
+        const colorDeactivated = env.NO_COLOR !== undefined;
+        return makeExpect({ 
+          ...mergedConfig, 
+          ...newConfig,
+          ...(colorDeactivated ? { colorize: false } : {})
+        });
+      },
+      get config(): ExpectConfig {
+        return { ...mergedConfig };
       },
     },
   );


### PR DESCRIPTION
This Pull Request adds support for the NO_COLOR environment variable.

When set, the `colorize` configuration option will always be enforced to false. If unset the colorize configuration option will be handled as usual.

ref #7 