### PR TITLE
Remove double quoting of string received values

### DIFF
--- a/expectNonRetrying.ts
+++ b/expectNonRetrying.ts
@@ -598,7 +598,9 @@ function createMatcherInfo(
     expected: typeof expected === "string"
       ? expected
       : JSON.stringify(expected),
-    received: JSON.stringify(received),
+    received: typeof received === "string"
+      ? received
+      : JSON.stringify(received),
     matcherSpecific,
     customMessage,
   };


### PR DESCRIPTION
This pull request includes a small change to the `createMatcherInfo` function in `expectNonRetrying.ts`. The change ensures that the `received` value is properly handled as a string or JSON stringified object, depending on its type.

This allows to avoid double quoting strings in a failed output `received` field, when the value is already a string and fixes #38.