### PR TITLE
Add `toHaveTitle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Use the same assertions you know from Playwright:
 // These Playwright assertions work exactly the same in k6
 await expect(page.locator(".button")).toBeVisible();
 await expect(page.locator("input")).toHaveValue("test");
+await expect(page).toHaveTitle("My Page Title");
 ```
 
 ### 2. Auto-Retrying Assertions
@@ -119,6 +120,8 @@ you must await them.
 
 By default, the timeout for assertions is set to 5 seconds, and the polling
 interval is set to 100 milliseconds.
+
+**Element Assertions (for Locators):**
 
 | Assertion                            | Description                                           |
 | ------------------------------------ | ----------------------------------------------------- |
@@ -133,13 +136,25 @@ interval is set to 100 milliseconds.
 | `toHaveText(text, opts?)`            | Element has text.                                     |
 | `toHaveValue(value)`                 | Element has specific value                            |
 
+**Page Assertions (for Pages):**
+
+| Assertion                  | Description                          |
+| -------------------------- | ------------------------------------ |
+| `toHaveTitle(text, opts?)` | Page title matches the expected text |
+
 You can customize these values by passing an options object as the second
 argument to the assertion function:
 
 ```javascript
+// Element assertions on locators
 await expect(page.locator(".button")).toBeVisible({
   timeout: 10000,
   interval: 500,
+});
+
+// Page assertions on page objects
+await expect(page).toHaveTitle("Expected Title", {
+  timeout: 5000,
 });
 ```
 

--- a/expectRetrying.test.ts
+++ b/expectRetrying.test.ts
@@ -110,8 +110,8 @@ Deno.test("negated retrying expectations", async (t) => {
       // Don't throw for this test
     };
 
-    // Import the createExpectation function directly to test it
-    const { createExpectation } = await import("./expectRetrying.ts");
+    // Import the createLocatorExpectation function directly to test it
+    const { createLocatorExpectation } = await import("./expectRetrying.ts");
 
     const config: ExpectConfig = {
       assertFn: mockAssert,
@@ -124,7 +124,7 @@ Deno.test("negated retrying expectations", async (t) => {
     };
 
     // Test with isNegated = true
-    const negatedExpectation = createExpectation(
+    const negatedExpectation = createLocatorExpectation(
       mockLocator as any,
       config,
       undefined,
@@ -181,8 +181,8 @@ Deno.test("negated retrying expectations", async (t) => {
       // Don't throw for this test
     };
 
-    // Import the createExpectation function directly to test it
-    const { createExpectation } = await import("./expectRetrying.ts");
+    // Import the createLocatorExpectation function directly to test it
+    const { createLocatorExpectation } = await import("./expectRetrying.ts");
 
     const config: ExpectConfig = {
       assertFn: mockAssert,
@@ -195,7 +195,7 @@ Deno.test("negated retrying expectations", async (t) => {
     };
 
     // Create an expectation
-    const expectation = createExpectation(
+    const expectation = createLocatorExpectation(
       mockLocator as any,
       config,
       undefined,

--- a/expectRetrying.ts
+++ b/expectRetrying.ts
@@ -579,6 +579,12 @@ export function createPageExpectation(
     display: config.display,
   });
 
+  // Register renderers specific to page matchers at initialization time.
+  MatcherErrorRendererRegistry.register(
+    "toHaveTitle",
+    new PageExpectedReceivedMatcherRenderer(),
+  );
+
   const matchPageText = async (
     matcherName: string,
     expected: RegExp | string,
@@ -936,6 +942,49 @@ export class ToHaveValueErrorRenderer extends ExpectedReceivedMatcherRenderer {
       {
         label: "",
         value: maybeColorize(`  - waiting for locator`, "darkGrey"),
+        group: 3,
+        raw: true,
+      },
+    ];
+  }
+}
+
+export class PageExpectedReceivedMatcherRenderer
+  extends ExpectedReceivedMatcherRenderer {
+  protected getMatcherName(): string {
+    return "pageExpectedReceived";
+  }
+
+  protected override getSpecificLines(
+    info: MatcherErrorInfo,
+    maybeColorize: (text: string, color: keyof typeof ANSI_COLORS) => string,
+  ): LineGroup[] {
+    const matcherName = info.matcherName;
+
+    return [
+      {
+        label: "Expected",
+        value: maybeColorize(info.expected, "green"),
+        group: 3,
+      },
+      {
+        label: "Received",
+        value: maybeColorize(info.received, "red"),
+        group: 3,
+      },
+      { label: "Call log", value: "", group: 3 },
+      {
+        label: "",
+        value: maybeColorize(
+          `  - expect.${matcherName}`,
+          "darkGrey",
+        ),
+        group: 3,
+        raw: true,
+      },
+      {
+        label: "",
+        value: maybeColorize(`  - waiting for page`, "darkGrey"),
         group: 3,
         raw: true,
       },

--- a/expectRetrying.ts
+++ b/expectRetrying.ts
@@ -17,6 +17,7 @@ import { parseStackTrace } from "./stacktrace.ts";
 import type { Locator, Page } from "k6/browser";
 import { normalizeWhiteSpace } from "./utils/string.ts";
 import { toHaveAttribute } from "./expectations/toHaveAttribute.ts";
+import { isLocator, isPage } from "./expectations/utils.ts";
 
 interface ToHaveTextOptions extends RetryConfig {
   /**
@@ -718,13 +719,15 @@ export function createExpectation(
   message?: string,
   isNegated: boolean = false,
 ): RetryingExpectation {
-  // For now, we'll just handle Locator (this will be updated in the next step)
-  return createLocatorExpectation(
-    target as Locator,
-    config,
-    message,
-    isNegated,
-  );
+  if (isPage(target)) {
+    return createPageExpectation(target, config, message, isNegated);
+  } else if (isLocator(target)) {
+    return createLocatorExpectation(target, config, message, isNegated);
+  } else {
+    throw new Error(
+      "Invalid target for retrying expectation. Expected Locator or Page object.",
+    );
+  }
 }
 
 // Helper function to create common matcher info

--- a/expectRetrying.ts
+++ b/expectRetrying.ts
@@ -140,24 +140,24 @@ export interface PageExpectation {
 export type RetryingExpectation = LocatorExpectation | PageExpectation;
 
 /**
- * createExpectation is a factory function that creates an expectation object for a given value.
+ * createLocatorExpectation is a factory function that creates an expectation object for Locator values.
  *
  * Note that although the browser `is` prefixed methods are used, and return boolean values, we
  * throw errors if the condition is not met. This is to ensure that we align with playwright's
  * API, and have matchers return `Promise<void>`, as opposed to `Promise<boolean>`.
  *
- * @param locator the value to create an expectation for
+ * @param locator the Locator to create an expectation for
  * @param config the configuration for the expectation
  * @param message the optional custom message for the expectation
  * @param isNegated whether the expectation is negated
- * @returns an expectation object over the given value exposing the Expectation set of methods
+ * @returns an expectation object over the locator exposing locator-specific methods
  */
-export function createExpectation(
+export function createLocatorExpectation(
   locator: Locator,
   config: ExpectConfig,
   message?: string,
   isNegated: boolean = false,
-): RetryingExpectation {
+): LocatorExpectation {
   // In order to facilitate testing, we support passing in a custom assert function.
   // As a result, we need to make sure that the assert function is always available, and
   // if not, we need to use the default assert function.
@@ -334,9 +334,9 @@ export function createExpectation(
     }
   };
 
-  const expectation: RetryingExpectation = {
-    get not(): RetryingExpectation {
-      return createExpectation(locator, config, message, !isNegated);
+  const expectation: LocatorExpectation = {
+    get not(): LocatorExpectation {
+      return createLocatorExpectation(locator, config, message, !isNegated);
     },
 
     async toBeChecked(
@@ -547,6 +547,184 @@ export function createExpectation(
   };
 
   return expectation;
+}
+
+/**
+ * createPageExpectation is a factory function that creates an expectation object for Page values.
+ *
+ * @param page the Page to create an expectation for
+ * @param config the configuration for the expectation
+ * @param message the optional custom message for the expectation
+ * @param isNegated whether the expectation is negated
+ * @returns an expectation object over the page exposing page-specific methods
+ */
+export function createPageExpectation(
+  page: Page,
+  config: ExpectConfig,
+  message?: string,
+  isNegated: boolean = false,
+): PageExpectation {
+  // In order to facilitate testing, we support passing in a custom assert function.
+  const usedAssert = config.assertFn ?? assert;
+  const isSoft = config.soft ?? false;
+  const retryConfig: RetryConfig = {
+    timeout: config.timeout,
+    interval: config.interval,
+  };
+
+  // Configure the renderer with the colorize option.
+  MatcherErrorRendererRegistry.configure({
+    colorize: config.colorize,
+    display: config.display,
+  });
+
+  const matchPageText = async (
+    matcherName: string,
+    expected: RegExp | string,
+    options: Partial<RetryConfig> = {},
+    compareFn: (actual: string, expected: string) => boolean,
+  ) => {
+    const stacktrace = parseStackTrace(new Error().stack);
+    const executionContext = captureExecutionContext(stacktrace);
+
+    if (!executionContext) {
+      throw new Error("k6 failed to capture execution context");
+    }
+
+    const checkRegExp = (expected: RegExp, actual: string) => {
+      // `ignoreCase` should take precedence over the `i` flag of the regex if it is defined.
+      const regexp = expected;
+
+      const info: MatcherErrorInfo = {
+        executionContext,
+        matcherName,
+        expected: regexp.toString(),
+        received: actual,
+        matcherSpecific: { isNegated },
+        customMessage: message,
+      };
+
+      const result = regexp.test(actual);
+
+      usedAssert(
+        isNegated ? !result : result,
+        MatcherErrorRendererRegistry.getRenderer(matcherName).render(
+          info,
+          MatcherErrorRendererRegistry.getConfig(),
+        ),
+        isSoft,
+        config.softMode,
+      );
+    };
+
+    const checkText = (expected: string, actual: string) => {
+      const normalizedExpected = normalizeWhiteSpace(expected);
+      const normalizedActual = normalizeWhiteSpace(actual);
+
+      const info: MatcherErrorInfo = {
+        executionContext,
+        matcherName,
+        expected: normalizedExpected,
+        received: normalizedActual,
+        matcherSpecific: { isNegated },
+        customMessage: message,
+      };
+
+      const result = compareFn(normalizedActual, normalizedExpected);
+
+      usedAssert(
+        isNegated ? !result : result,
+        MatcherErrorRendererRegistry.getRenderer(matcherName).render(
+          info,
+          MatcherErrorRendererRegistry.getConfig(),
+        ),
+        isSoft,
+        config.softMode,
+      );
+    };
+
+    try {
+      await withRetry(
+        async () => {
+          const actualText = await page.title();
+
+          if (expected instanceof RegExp) {
+            checkRegExp(expected, actualText);
+
+            return;
+          }
+
+          checkText(expected, actualText);
+        },
+        { ...retryConfig, ...options },
+      );
+    } catch (_) {
+      const info: MatcherErrorInfo = {
+        executionContext,
+        matcherName,
+        expected: expected.toString(),
+        received: "unknown",
+        matcherSpecific: { isNegated },
+        customMessage: message,
+      };
+
+      usedAssert(
+        false,
+        MatcherErrorRendererRegistry.getRenderer("toHaveTitle").render(
+          info,
+          MatcherErrorRendererRegistry.getConfig(),
+        ),
+        isSoft,
+        config.softMode,
+      );
+    }
+  };
+
+  const expectation: PageExpectation = {
+    get not(): PageExpectation {
+      return createPageExpectation(page, config, message, !isNegated);
+    },
+
+    toHaveTitle(
+      expected: RegExp | string,
+      options: Partial<RetryConfig> = {},
+    ) {
+      return matchPageText(
+        "toHaveTitle",
+        expected,
+        options,
+        (actual, expected) => actual === expected,
+      );
+    },
+  };
+
+  return expectation;
+}
+
+/**
+ * createExpectation is a factory function that creates an expectation object for a given value.
+ *
+ * This function routes to the appropriate specialized factory based on the input type.
+ *
+ * @param target the value to create an expectation for (Locator or Page)
+ * @param config the configuration for the expectation
+ * @param message the optional custom message for the expectation
+ * @param isNegated whether the expectation is negated
+ * @returns an expectation object exposing the appropriate methods
+ */
+export function createExpectation(
+  target: Locator | Page,
+  config: ExpectConfig,
+  message?: string,
+  isNegated: boolean = false,
+): RetryingExpectation {
+  // For now, we'll just handle Locator (this will be updated in the next step)
+  return createLocatorExpectation(
+    target as Locator,
+    config,
+    message,
+    isNegated,
+  );
 }
 
 // Helper function to create common matcher info

--- a/expectRetrying.ts
+++ b/expectRetrying.ts
@@ -14,7 +14,7 @@ import {
   ReceivedOnlyMatcherRenderer,
 } from "./render.ts";
 import { parseStackTrace } from "./stacktrace.ts";
-import type { Locator } from "k6/browser";
+import type { Locator, Page } from "k6/browser";
 import { normalizeWhiteSpace } from "./utils/string.ts";
 import { toHaveAttribute } from "./expectations/toHaveAttribute.ts";
 
@@ -32,18 +32,14 @@ interface ToHaveTextOptions extends RetryConfig {
 }
 
 /**
- * RetryingExpectation is an interface that defines the methods that can be used to create a retrying expectation.
- *
- * Retrying expectations are used to assert that a condition is met within a given timeout.
- * The provided assertion function is called repeatedly until the condition is met or the timeout is reached.
- *
- * The RetryingExpectation interface is implemented by the createExpectation function.
+ * LocatorExpectation defines methods for asserting on Locator objects (DOM elements).
+ * These assertions retry automatically until they pass or timeout.
  */
-export interface RetryingExpectation {
+export interface LocatorExpectation {
   /**
    * Negates the expectation, causing the assertion to pass when it would normally fail, and vice versa.
    */
-  not: RetryingExpectation;
+  not: LocatorExpectation;
 
   /**
    * Ensures the Locator points to a checked input.
@@ -115,6 +111,33 @@ export interface RetryingExpectation {
    */
   toHaveValue(value: string, options?: Partial<RetryConfig>): Promise<void>;
 }
+
+/**
+ * PageExpectation defines methods for asserting on Page objects (browser pages).
+ * These assertions retry automatically until they pass or timeout.
+ */
+export interface PageExpectation {
+  /**
+   * Negates the expectation, causing the assertion to pass when it would normally fail, and vice versa.
+   */
+  not: PageExpectation;
+
+  /**
+   * Ensures that the Page's title matches the given title.
+   */
+  toHaveTitle(
+    expected: RegExp | string,
+    options?: Partial<RetryConfig>,
+  ): Promise<void>;
+}
+
+/**
+ * RetryingExpectation is a union type that supports both locator-based and page-based expectations.
+ *
+ * Retrying expectations are used to assert that a condition is met within a given timeout.
+ * The provided assertion function is called repeatedly until the condition is met or the timeout is reached.
+ */
+export type RetryingExpectation = LocatorExpectation | PageExpectation;
 
 /**
  * createExpectation is a factory function that creates an expectation object for a given value.

--- a/expectations/utils.ts
+++ b/expectations/utils.ts
@@ -1,4 +1,4 @@
-import type { Locator } from "k6/browser";
+import type { Locator, Page } from "k6/browser";
 
 /**
  * Checks if the given value is a browser Locator.
@@ -51,5 +51,39 @@ export function isLocator(value: unknown): value is Locator {
     value !== undefined &&
     typeof value === "object" &&
     hasLocatorProperties(value)
+  );
+}
+
+/**
+ * Checks if the given value is a browser Page.
+ *
+ * If it quacks like a duck, it's a duck.
+ *
+ * @param value The value to check.
+ * @returns Whether the value is a Page.
+ */
+export function isPage(value: unknown): value is Page {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const pageProperties = [
+    "title",
+    "goto",
+    "url",
+    "close",
+    "mainFrame",
+    "waitForLoadState",
+  ];
+
+  const hasPageProperties = (value: object): boolean => {
+    return pageProperties.every((prop) => prop in value);
+  };
+
+  return (
+    value !== null &&
+    value !== undefined &&
+    typeof value === "object" &&
+    hasPageProperties(value)
   );
 }

--- a/tests/expect-retrying.js
+++ b/tests/expect-retrying.js
@@ -400,8 +400,14 @@ export default async function testExpectRetrying() {
     const page = await context.newPage();
     try {
       await page.goto("http://localhost:8000");
-      const locator = page.locator(testCase.selector);
-      await testCase.assertion(locator);
+
+      if (testCase.selector) {
+        const locator = page.locator(testCase.selector);
+        await testCase.assertion(locator);
+      } else {
+        await testCase.assertion({ page });
+      }
+
       passTest(testCase.name);
     } catch (error) {
       console.error(`Test case "${testCase.name}" failed: ${error.message}`);

--- a/tests/expect-retrying.js
+++ b/tests/expect-retrying.js
@@ -165,6 +165,27 @@ const standardTestCases = [
     ],
   },
   {
+    suite: "toHaveTitle",
+    children: [
+      {
+        name: "string",
+        assertion: async ({ page }) => {
+          await expect(page).toHaveTitle(
+            "K6 Browser Test Page",
+          );
+        },
+      },
+      {
+        name: "regexp",
+        assertion: async ({ page }) => {
+          await expect(page).toHaveTitle(
+            /K6 Browser Test Page/i,
+          );
+        },
+      },
+    ],
+  },
+  {
     suite: "toContainText",
     children: [
       {
@@ -296,6 +317,12 @@ const negationTestCases = [
     selector: "#toHaveText",
     assertion: async (locator) => {
       await expect(locator).not.toHaveText("This is not at all what it says!");
+    },
+  },
+  {
+    name: "not.toHaveTitle",
+    assertion: async ({ page }) => {
+      await expect(page).not.toHaveTitle("Hello World");
     },
   },
   {


### PR DESCRIPTION
# What

- This adds the ability to perform an expect on page for a title.
- I had to refactor the code to split between `locator` and `page` based expectations.

# Why

- Makes the migration from Playwright a little easier, especially the example playwright test script.

# How

The implementation matches Playwright: https://github.com/microsoft/playwright/blob/7cab4ec393be25449d47f2a471b1439d3c5df5fd/packages/injected/src/injectedScript.ts#L1351-L1354