### PR TITLE
Pin CI deno version to 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2
         with:
-          deno-version: v2.x
+          deno-version: "~2.4"
 
       - name: Check Formatting
         run: deno fmt --check


### PR DESCRIPTION
This pull request updates the Deno setup in the CI workflow to use a specific version of Deno rather than a version range. This ensures consistent builds and reduces the risk of unexpected changes due to automatic upgrades.

* CI configuration: Changed the `deno-version` in `.github/workflows/ci.yml` from `v2.x` to `"v2.4"` to pin the Deno version for workflow runs.