### PR TITLE
ci: update release gh action to use denoland/setup-deno action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Deno v2
-        uses: denolib/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2
+      - name: Setup Deno
+        uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2
         with:
-          deno-version: v2.x
+          deno-version: "~2.4"
 
       - name: Build & archive
         run: |


### PR DESCRIPTION
This pull request updates the Deno setup step in the release workflow to use the official `denoland/setup-deno` action and specifies a more precise Deno version. These changes improve reliability and ensure consistent environment setup.

Workflow improvements:

* Updated the Deno installation step in `.github/workflows/release.yml` to use the official `denoland/setup-deno` action instead of `denolib/setup-deno`, and changed the version specification to `"~2.4"` for more precise control over the installed Deno version.