### PR TITLE
Make test server pick random port and be configurable

### DIFF
--- a/tests/expect-retrying.js
+++ b/tests/expect-retrying.js
@@ -395,6 +395,7 @@ function flattenSuites(tests) {
 }
 
 export default async function testExpectRetrying() {
+  const baseUrl = __ENV.TEST_SERVER_BASE_URL ?? "http://localhost:8000";
   const context = await browser.newContext();
 
   const testCases = [...testItems, ...standardTestCases];
@@ -403,7 +404,7 @@ export default async function testExpectRetrying() {
   for (const testCase of flattenSuites(testCases)) {
     const page = await context.newPage();
     try {
-      await page.goto("http://localhost:8000");
+      await page.goto(baseUrl);
 
       if (testCase.selector) {
         const locator = page.locator(testCase.selector);
@@ -437,7 +438,7 @@ export default async function testExpectRetrying() {
   for (const testCase of flattenSuites(negationTestCases)) {
     const page = await context.newPage();
     try {
-      await page.goto("http://localhost:8000");
+      await page.goto(baseUrl);
 
       if (testCase.selector) {
         const locator = page.locator(testCase.selector);

--- a/tests/testserver.ts
+++ b/tests/testserver.ts
@@ -1,6 +1,8 @@
 import { serveFile } from "@std/http/file-server";
 
-Deno.serve((req: Request) => {
+const port = Number(Deno.env.get("TEST_SERVER_PORT") ?? "8000");
+
+Deno.serve({ hostname: "127.0.0.1", port }, (req: Request) => {
   const pathname = new URL(req.url).pathname;
   if (pathname === "/") {
     const filepath = new URL("./test.html", import.meta.url).pathname;


### PR DESCRIPTION
This pull request addresses persistent issues I encountered on my local setup with the test server reusing already (common) taken ports, and binding to localhost specifically. It make the test server more consistent, configurable, and has removed all flakiness on my end.

It updates the test infrastructure to allow dynamic configuration of the test server's base URL and port, improving compatibility and flexibility for different environments. It also adds support for configuring the URL and port from the environment. The main changes ensure that both the test server and test cases use a dynamically assigned port, passed via environment variables.

**Test server configuration improvements:**

* [`tests/testserver.ts`](diffhunk://#diff-047e26b50606d327c645dc2472b6212b9f768d5502d2115e080715b7883db358L3-R5): The test server now reads its port from the `TEST_SERVER_PORT` environment variable and binds to `127.0.0.1` at that port, instead of always using port 8000.
* [`tests/run-tests.ts`](diffhunk://#diff-b9db080ade434fdf2d600101f888527535dd48bed4b8ac8c25a81e0154efdda5R2-R20): Before starting the test server, the code allocates a free port and sets `TEST_SERVER_PORT` in the environment for the server process. The test runner also sets `TEST_SERVER_BASE_URL` for the test scripts to use.

**Test script improvements:**

* [`tests/expect-retrying.js`](diffhunk://#diff-4e0fe2187036003fdbab5ac147595fb15f5c2eff73dee338025bcc150127370aR398): The test script now uses the `TEST_SERVER_BASE_URL` environment variable (defaulting to `http://localhost:8000` if unset) for all page navigation, replacing hardcoded URLs. [[1]](diffhunk://#diff-4e0fe2187036003fdbab5ac147595fb15f5c2eff73dee338025bcc150127370aR398) [[2]](diffhunk://#diff-4e0fe2187036003fdbab5ac147595fb15f5c2eff73dee338025bcc150127370aL406-R407) [[3]](diffhunk://#diff-4e0fe2187036003fdbab5ac147595fb15f5c2eff73dee338025bcc150127370aL440-R441)
* [`tests/run-tests.ts`](diffhunk://#diff-b9db080ade434fdf2d600101f888527535dd48bed4b8ac8c25a81e0154efdda5R51-R54): When invoking the test scripts, the runner sets `TEST_SERVER_BASE_URL` in the environment to ensure they use the correct dynamic URL.