### PR TITLE
feat: add toBeInViewport locator assertion

### DIFF
--- a/expect/matchers/browser/index.ts
+++ b/expect/matchers/browser/index.ts
@@ -4,6 +4,7 @@ import "./toBeEditable.ts";
 import "./toBeEmpty.ts";
 import "./toBeEnabled.ts";
 import "./toBeHidden.ts";
+import "./toBeInViewport.ts";
 import "./toBeVisible.ts";
 import "./toHaveAttribute.ts";
 import "./toHaveText.ts";

--- a/expect/matchers/browser/toBeInViewport.test.ts
+++ b/expect/matchers/browser/toBeInViewport.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "@std/assert";
+import type { Locator } from "k6/browser";
+import {
+  createMatchersWithSpy,
+  createMockLocator,
+} from "../../../test_helpers.ts";
+
+Deno.test("toBeInViewport passes ratio to locator.isInViewport", async () => {
+  const [spy, expect] = createMatchersWithSpy();
+  let receivedOptions: { ratio?: number } | undefined;
+
+  const locator = createMockLocator({
+    isInViewport: (options) => {
+      receivedOptions = options;
+
+      return Promise.resolve(true);
+    },
+  }) as Locator;
+
+  await expect(locator).toBeInViewport({ ratio: 0.5, timeout: 1 });
+
+  assertEquals(spy.called, false);
+  assertEquals(receivedOptions, { ratio: 0.5 });
+});

--- a/expect/matchers/browser/toBeInViewport.ts
+++ b/expect/matchers/browser/toBeInViewport.ts
@@ -1,0 +1,65 @@
+import type { Locator } from "k6/browser";
+import { DEFAULT_RETRY_OPTIONS, type RetryConfig } from "../../../config.ts";
+import { type AnyError, AssertionFailed } from "../../errors.ts";
+import { extend } from "../../extend.ts";
+import { green, red } from "../../formatting/index.ts";
+import { isLocatorWithViewport, withRetry } from "./utils.ts";
+
+export interface ToBeInViewportOptions extends RetryConfig {
+  ratio?: number;
+}
+
+declare module "../../extend.ts" {
+  export interface Matchers<Received> {
+    /**
+     * Ensures that Locator points to a DOM node that intersects the viewport.
+     */
+    toBeInViewport: Received extends Locator
+      ? (options?: Partial<ToBeInViewportOptions>) => Promise<void>
+      : never;
+  }
+}
+
+function inViewportMessage(expected: string, received: string): AnyError {
+  return {
+    format: "custom",
+    content: {
+      Expected: green(expected),
+      Received: red(received),
+    },
+  };
+}
+
+extend("toBeInViewport", {
+  match(received, options?: Partial<ToBeInViewportOptions>) {
+    if (!isLocatorWithViewport(received)) {
+      throw new AssertionFailed({
+        format: "type-mismatch",
+        expected: [{ name: "Locator" }],
+        received: received,
+      });
+    }
+
+    const retryOptions: Required<RetryConfig> = {
+      ...DEFAULT_RETRY_OPTIONS,
+      ...this.config,
+      ...options,
+    };
+
+    return withRetry(this, retryOptions, async () => {
+      const inViewport = await received.isInViewport(
+        options?.ratio === undefined ? undefined : { ratio: options.ratio },
+      );
+
+      if (!inViewport) {
+        throw new AssertionFailed(
+          inViewportMessage("in viewport", "outside viewport"),
+        );
+      }
+
+      return {
+        negate: inViewportMessage("outside viewport", "in viewport"),
+      };
+    });
+  },
+});

--- a/expect/matchers/browser/utils.ts
+++ b/expect/matchers/browser/utils.ts
@@ -60,6 +60,16 @@ export function isLocator(value: unknown): value is Locator {
   );
 }
 
+export interface LocatorWithViewport extends Locator {
+  isInViewport(options?: { ratio?: number }): Promise<boolean>;
+}
+
+export function isLocatorWithViewport(
+  value: unknown,
+): value is LocatorWithViewport {
+  return isLocator(value) && "isInViewport" in value;
+}
+
 /**
  * Checks if the given value is a browser Page.
  *

--- a/test_helpers.ts
+++ b/test_helpers.ts
@@ -2,7 +2,7 @@
 import "./expect/matchers/index.ts";
 import "./expect/formats/index.ts";
 
-import type { Locator } from "k6/browser";
+import type { LocatorWithViewport } from "./expect/matchers/browser/utils.ts";
 import type { ExpectConfig } from "./config.ts";
 import { env } from "./environment.ts";
 import { createMatchers } from "./expect/extend.ts";
@@ -54,7 +54,7 @@ export function createMatchersWithSpy() {
   ] as const;
 }
 
-export function createMockLocator(mock: Partial<Locator>) {
+export function createMockLocator(mock: Partial<LocatorWithViewport>) {
   return {
     "clear": () => {
       return Promise.reject(new Error("Not implemented"));
@@ -126,6 +126,9 @@ export function createMockLocator(mock: Partial<Locator>) {
       return Promise.reject(new Error("Not implemented"));
     },
     "isVisible": () => {
+      return Promise.reject(new Error("Not implemented"));
+    },
+    "isInViewport": () => {
       return Promise.reject(new Error("Not implemented"));
     },
     "innerHTML": () => {

--- a/tests/expect-retrying.ts
+++ b/tests/expect-retrying.ts
@@ -1,3 +1,4 @@
+import "./expectations/toBeInViewport.ts";
 import "./expectations/toHaveAttribute.ts";
 
 import {

--- a/tests/expectations/toBeInViewport.ts
+++ b/tests/expectations/toBeInViewport.ts
@@ -1,0 +1,100 @@
+import type { Page } from "k6/browser";
+import { describe, it } from "../helpers/browser.ts";
+import { dedent } from "../utils.ts";
+
+async function renderCtaButton(page: Page, style: string) {
+  await page.evaluate((style) => {
+    document.body.innerHTML = "";
+    document.body.style.margin = "0";
+    document.body.style.minHeight = "2200px";
+
+    const button = document.createElement("button");
+    button.id = "cta-button";
+    button.textContent = "Call to action";
+    button.setAttribute("style", style);
+
+    document.body.appendChild(button);
+  }, style);
+}
+
+describe("toBeInViewport", () => {
+  it("should pass when the element is in the viewport", async ({ expect, page, spy }) => {
+    await renderCtaButton(page, "position: fixed; top: 20px; left: 20px;");
+
+    await spy.expect(page.locator("#cta-button")).toBeInViewport();
+
+    expect(spy.result.passed).toBe(true);
+  });
+
+  it("should support ratio option", async ({ expect, page, spy }) => {
+    await renderCtaButton(page, "position: fixed; top: 20px; left: 20px;");
+
+    await spy.expect(page.locator("#cta-button")).toBeInViewport({
+      ratio: 0.5,
+    });
+
+    expect(spy.result.passed).toBe(true);
+  });
+
+  it("should fail when the element is outside the viewport", async ({ expect, page, spy }) => {
+    await renderCtaButton(
+      page,
+      "position: absolute; top: 2000px; left: 20px;",
+    );
+
+    await spy.expect(page.locator("#cta-button")).toBeInViewport({
+      timeout: 20,
+      interval: 10,
+    });
+
+    expect(spy.result.passed).toBe(false);
+    expect(spy.result.message).toEqual(dedent`
+         Error: expect(received).toBeInViewport(options)
+            At: ...
+
+      Expected: in viewport
+      Received: outside viewport
+
+      Call log:${" "}
+        - expect.toBeInViewport with timeout 20ms
+        - assertion toBeInViewport failed (xN)
+
+      Filename: toBeInViewport.ts
+          Line: ...
+    `);
+  });
+
+  describe("not", () => {
+    it("should pass when the element is outside the viewport", async ({ expect, page, spy }) => {
+      await renderCtaButton(
+        page,
+        "position: absolute; top: 2000px; left: 20px;",
+      );
+
+      await spy.expect(page.locator("#cta-button")).not.toBeInViewport();
+
+      expect(spy.result.passed).toBe(true);
+    });
+
+    it("should fail when the element is in the viewport", async ({ expect, page, spy }) => {
+      await renderCtaButton(page, "position: fixed; top: 20px; left: 20px;");
+
+      await spy.expect(page.locator("#cta-button")).not.toBeInViewport();
+
+      expect(spy.result.passed).toBe(false);
+      expect(spy.result.message).toEqual(dedent`
+           Error: expect(received).not.toBeInViewport()
+              At: ...
+
+        Expected: outside viewport
+        Received: in viewport
+
+        Call log:${" "}
+          - expect.toBeInViewport with timeout 5000ms
+
+        Filename: toBeInViewport.ts
+            Line: ...
+      `);
+    });
+  });
+});

--- a/tests/suite.ts
+++ b/tests/suite.ts
@@ -3,6 +3,7 @@ import execution from "k6/execution";
 import { suite } from "./helpers/test.ts";
 
 import "./expectations/toBeInstanceOf.ts";
+import "./expectations/toBeInViewport.ts";
 import "./expectations/toHaveAttribute.ts";
 import "./expectations/toHaveProperty.ts";
 import { colorize } from "../colors.ts";


### PR DESCRIPTION
## Summary

Adds `expect(locator).toBeInViewport()` for browser locators, backed by k6's `Locator.isInViewport()` API. The matcher uses the existing retry flow, supports `.not`, and forwards only the optional `{ ratio }` argument to the locator API while keeping retry options local to the assertion.

This also adds focused coverage for the ratio pass-through path and browser expectation cases for visible, out-of-viewport, and negated assertions.

Closes #97

## Verification

- `deno fmt --check expect/matchers/browser/toBeInViewport.ts expect/matchers/browser/index.ts expect/matchers/browser/utils.ts test_helpers.ts tests/expectations/toBeInViewport.ts expect/matchers/browser/toBeInViewport.test.ts tests/expect-retrying.ts tests/suite.ts`
- `deno lint expect/matchers/browser/toBeInViewport.ts expect/matchers/browser/utils.ts test_helpers.ts tests/expectations/toBeInViewport.ts expect/matchers/browser/toBeInViewport.test.ts tests/expect-retrying.ts tests/suite.ts`
- `deno test --allow-env expect/matchers/browser/toBeInViewport.test.ts`
- `deno check mod.ts`
- `deno task build`

`deno task test` could not run fully in this environment because the `k6` binary is not installed (`Failed to spawn 'k6': entity not found`).
